### PR TITLE
4. Exercise: Refactor LabelsContext to a generic DataStoreContext

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import CreateIssue from "./CreateIssue";
 import IssueDetails from "./IssueDetails";
 import PageNotFound from "./PageNotFound";
 import { fetchLabels, fetchIssues, destroyIssue, saveIssue } from "./api";
-import { LabelsContext } from "./contexts";
+import { DataStoreContext } from "./contexts";
 
 function App() {
   const [labels, setLabels] = useState([]);
@@ -71,13 +71,13 @@ function App() {
   }
 
   return (
-    <LabelsContext.Provider value={labels}>
+    <DataStoreContext.Provider value={{ labels, labelsById, issues }}>
       <Router>
         <div className="container mt-3">
           <h1>Issues</h1>
           <Switch>
             <Route path="/" exact={true}>
-              <Issues issues={issues} labels={labels} labelsById={labelsById} />
+              <Issues />
             </Route>
             <Route path="/issues/:id" exact={true}>
               <IssueDetails deleteIssue={deleteIssue} editIssue={editIssue} />
@@ -91,7 +91,7 @@ function App() {
           </Switch>
         </div>
       </Router>
-    </LabelsContext.Provider>
+    </DataStoreContext.Provider>
   );
 }
 

--- a/src/IssueForm.js
+++ b/src/IssueForm.js
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from "react";
-import { LabelsContext } from "./contexts";
+import { DataStoreContext } from "./contexts";
 
 export default function IssueForm({
   onSubmit,
@@ -7,7 +7,7 @@ export default function IssueForm({
 }) {
   const [title, setTitle] = useState(issue.title);
   const [labelId, setLabelId] = useState(issue.label);
-  const labels = useContext(LabelsContext);
+  const { labels } = useContext(DataStoreContext);
 
   function handleSubmit(event) {
     event.preventDefault();

--- a/src/IssueList.js
+++ b/src/IssueList.js
@@ -1,7 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Link } from "react-router-dom";
+import { DataStoreContext } from "./contexts";
 
-export default function IssueList({ issues, labels, labelsById }) {
+export default function IssueList({ issues }) {
+  const { labelsById } = useContext(DataStoreContext);
+
   return (
     <ul className="list-group">
       {issues.map((issue) => {

--- a/src/Issues.js
+++ b/src/Issues.js
@@ -1,8 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import IssueList from "./IssueList";
 import { Link } from "react-router-dom";
+import { DataStoreContext } from "./contexts";
 
-export default function Issues({ issues, labels, labelsById }) {
+export default function Issues() {
+  const { issues, labels } = useContext(DataStoreContext);
   const [selectedLabelId, setSelectedLabelId] = useState();
   const [filteredIssues, setFilteredIssues] = useState(issues);
 
@@ -54,11 +56,7 @@ export default function Issues({ issues, labels, labelsById }) {
         </select>
       </div>
 
-      <IssueList
-        issues={filteredIssues}
-        labels={labels}
-        labelsById={labelsById}
-      />
+      <IssueList issues={filteredIssues} />
     </>
   );
 }

--- a/src/contexts.js
+++ b/src/contexts.js
@@ -1,3 +1,3 @@
 import { createContext } from "react";
 
-export const LabelsContext = createContext();
+export const DataStoreContext = createContext();


### PR DESCRIPTION
# Exercise

Refactor `LabelsContext` to be a more generic context called `DataStoreContext` where the value of this context is an object that contains `labels`, `issues`, and `labelsById`. Consume this context in all components so there isn't a need to pass `labels`, `issues`, or `labelsById` as props.